### PR TITLE
Move the shift key to `z` and `/`, remove waiting delay

### DIFF
--- a/keyboards/mac-izumi.kbd
+++ b/keyboards/mac-izumi.kbd
@@ -36,15 +36,14 @@
 (defalias
   ;; modifiers on colemak's btm row 
   ;; reason: colemak uses home row extensively
-  z (tap-hold-next-release 200 z lctl)	
-  x (tap-hold-next-release 200 x lalt)	
-  c (tap-hold-next-release 200 c lmet)	
-  d (tap-hold-next-release 200 d lsft)	
+  z (tap-hold-next-release 200 (sticky-key 500 lsft) z)
+  x (tap-hold-next-release 200 x lctl)	
+  c (tap-hold-next-release 200 c lalt)	
+  d (tap-hold-next-release 200 d lmet)	
 
-  h  (tap-hold-next-release 200 h rsft)	
-  cm (tap-hold-next-release 200 , rmet)	
-  pd (tap-hold-next-release 200 . ralt)	
-  sl (tap-hold-next-release 200 / rctl)	
+  h  (tap-hold-next-release 200 h rmet)	
+  cm (tap-hold-next-release 200 , ralt)	
+  pd (tap-hold-next-release 200 . rctl)	
 
   ;; modifiers on qwerty's btm row 
   ;; reason: free WASD for Unity

--- a/keyboards/mac-izumi.kbd
+++ b/keyboards/mac-izumi.kbd
@@ -44,6 +44,7 @@
   h  (tap-hold-next-release 200 h rmet)	
   cm (tap-hold-next-release 200 , ralt)	
   pd (tap-hold-next-release 200 . rctl)	
+  sl (tap-hold-next-release 200 (sticky-key 500 rsft) /)
 
   ;; modifiers on qwerty's btm row 
   ;; reason: free WASD for Unity

--- a/keyboards/mac-izumi.kbd
+++ b/keyboards/mac-izumi.kbd
@@ -36,7 +36,7 @@
 (defalias
   ;; modifiers on colemak's btm row 
   ;; reason: colemak uses home row extensively
-  z (tap-hold-next-release 200 (sticky-key 500 lsft) z)
+  z (tap-next-release z lsft) ;; z is used less than the inner letters. no delay, when held, becomes shift if you press another key. if you keep holding this after pressing another one, it stays as shift
   x (tap-hold-next-release 200 x lctl)	
   c (tap-hold-next-release 200 c lalt)	
   d (tap-hold-next-release 200 d lmet)	
@@ -44,12 +44,12 @@
   h  (tap-hold-next-release 200 h rmet)	
   cm (tap-hold-next-release 200 , ralt)	
   pd (tap-hold-next-release 200 . rctl)	
-  sl (tap-hold-next-release 200 (sticky-key 500 rsft) /)
+  sl (tap-next-release / rsft)
 
   ;; modifiers on qwerty's btm row 
   ;; reason: free WASD for Unity
-  v (tap-hold-next-release 200 v lsft)
-  m (tap-hold-next-release 200 m rsft)
+  v (tap-hold-next-release 200 v lmet)
+  m (tap-hold-next-release 200 m rmet)
 
   ;; thumb layers
   escs (tap-hold-next-release 200 esc (layer-toggle CODE))

--- a/keyboards/win-izumi.kbd
+++ b/keyboards/win-izumi.kbd
@@ -36,7 +36,7 @@
 (defalias
   ;; modifiers on colemak's btm row 
   ;; reason: colemak uses home row extensively
-  z (tap-hold-next-release 200 (sticky-key 500 lsft) z)
+  z (tap-next-release z lsft)
   x (tap-hold-next-release 200 x lmet)	
   c (tap-hold-next-release 200 c lalt)	
   d (tap-hold-next-release 200 d lctl)	
@@ -44,12 +44,12 @@
   h  (tap-hold-next-release 200 h rctl)	
   cm (tap-hold-next-release 200 , ralt)	
   pd (tap-hold-next-release 200 . rmet)	
-  sl (tap-hold-next-release 200 (sticky-key 500 rsft) /)	
+  sl (tap-next-release / rsft)
 
   ;; modifiers on qwerty's btm row 
   ;; reason: free WASD for Unity
-  v (tap-hold-next-release 200 v lsft)
-  m (tap-hold-next-release 200 m rsft)
+  v (tap-hold-next-release 200 v lctl)
+  m (tap-hold-next-release 200 m rctl)
 
   ;; thumb layers
   escs (tap-hold-next-release 200 esc (layer-toggle CODE))

--- a/keyboards/win-izumi.kbd
+++ b/keyboards/win-izumi.kbd
@@ -36,15 +36,15 @@
 (defalias
   ;; modifiers on colemak's btm row 
   ;; reason: colemak uses home row extensively
-  z (tap-hold-next-release 200 z lmet)	
-  x (tap-hold-next-release 200 x lalt)	
-  c (tap-hold-next-release 200 c lctl)	
-  d (tap-hold-next-release 200 d lsft)	
+  z (tap-hold-next-release 200 (sticky-key 500 lsft) z)
+  x (tap-hold-next-release 200 x lmet)	
+  c (tap-hold-next-release 200 c lalt)	
+  d (tap-hold-next-release 200 d lctl)	
 
-  h  (tap-hold-next-release 200 h rsft)	
-  cm (tap-hold-next-release 200 , rctl)	
-  pd (tap-hold-next-release 200 . ralt)	
-  sl (tap-hold-next-release 200 / rmet)	
+  h  (tap-hold-next-release 200 h rctl)	
+  cm (tap-hold-next-release 200 , ralt)	
+  pd (tap-hold-next-release 200 . rmet)	
+  sl (tap-hold-next-release 200 (sticky-key 500 rsft) /)	
 
   ;; modifiers on qwerty's btm row 
   ;; reason: free WASD for Unity


### PR DESCRIPTION
I lost to the wampus 3 times today. I was so salty that the shift key timing was really getting in the way, and so i moved it to somewhere less commonly pressed and removed the delay.

now the bottom row mods on mac are SCAM, but in the layers they are still CAMS for the muscle memory I have already built up for navigating notion and similar apps. It is also more suited for holding.